### PR TITLE
Update CheckAICapacity to use abstracted interface

### DIFF
--- a/cmd/livepeer/starter/starter.go
+++ b/cmd/livepeer/starter/starter.go
@@ -618,7 +618,9 @@ func StartLivepeer(ctx context.Context, cfg LivepeerConfig) {
 				if len(aiCaps) > 0 {
 					capability := aiCaps[len(aiCaps)-1]
 					price := n.GetBasePriceForCap("default", capability, config.ModelID)
-					glog.V(6).Infof("Capability %s (ID: %v) advertised with model constraint %s at price %d per %d unit", config.Pipeline, capability, config.ModelID, price.Num(), price.Denom())
+					if price != nil {
+						glog.V(6).Infof("Capability %s (ID: %v) advertised with model constraint %s at price %d per %d unit", config.Pipeline, capability, config.ModelID, price.Num(), price.Denom())
+					}
 				}
 			}
 		} else {

--- a/core/ai.go
+++ b/core/ai.go
@@ -223,7 +223,23 @@ func (m *RemoteAIWorkerManager) Stop(ctx context.Context) error {
 }
 
 func (m *RemoteAIWorkerManager) HasCapacity(pipeline, modelID string) bool {
-	return false
+	m.workersMutex.Lock()
+	defer m.workersMutex.Unlock()
+	var cap Capability
+	switch pipeline {
+	case "text-to-image":
+		cap = Capability_TextToImage
+	case "image-to-image":
+		cap = Capability_ImageToImage
+	case "upscale":
+		cap = Capability_Upscale
+	case "image-to-video":
+		cap = Capability_ImageToVideo
+	default:
+		return false
+	}
+	return len(m.remoteWorkers[cap][modelID]) > 0
+
 }
 
 func (m *RemoteAIWorkerManager) aiResult(res *RemoteAIWorkerResult) {

--- a/core/capabilities.go
+++ b/core/capabilities.go
@@ -6,6 +6,7 @@ import (
 
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/go-livepeer/net"
 	"github.com/livepeer/go-tools/drivers"
 	"github.com/livepeer/lpms/ffmpeg"
@@ -516,6 +517,7 @@ func (cap *Capabilities) AddCapacity(newCaps *Capabilities) {
 		curCapacity, e := cap.capacities[capability]
 		if !e {
 			cap.capacities[capability] = 0
+			glog.Infof("Adding new capability %v", capability)
 		}
 		cap.capacities[capability] = curCapacity + capacity
 		arrIdx := int(capability) / 64

--- a/core/orchestrator.go
+++ b/core/orchestrator.go
@@ -97,18 +97,7 @@ func (orch *orchestrator) CheckCapacity(mid ManifestID) error {
 func (orch *orchestrator) CheckAICapacity(pipeline, modelID string) bool {
 	// TODO: Pass cap instead? Considering it's a public function might be
 	// better to pass the string directly
-	var cap Capability
-	switch pipeline {
-	case "text-to-image":
-		cap = Capability_TextToImage
-	case "image-to-image":
-		cap = Capability_ImageToImage
-	case "upscale":
-		cap = Capability_Upscale
-	default:
-		return false
-	}
-	return len(orch.node.AIManager.remoteWorkers[cap][modelID]) > 0
+	return orch.node.AIWorker.HasCapacity(pipeline, modelID)
 }
 
 func (orch *orchestrator) TranscodeSeg(ctx context.Context, md *SegTranscodingMetadata, seg *stream.HLSSegment) (*TranscodeResult, error) {


### PR DESCRIPTION
Update CheckAICapacity to abstract away using an AIWorker directly or a RemoteAIWorkerManager